### PR TITLE
Align components with bootstrap 4 markup

### DIFF
--- a/addon/components/input-validator.js
+++ b/addon/components/input-validator.js
@@ -10,7 +10,7 @@ import FormValidatorChild from './form-validator/child';
 export default Component.extend({
     layout,
     classNames: [ 'form-group', 'input-validator' ],
-    classNameBindings: ['showError:has-warning', 'label:has-label'],
+    classNameBindings: ['showError:is-invalid', 'label:has-label'],
     labelClass: 'control-label',
     errorClass: 'invalid-feedback',
     label: false,

--- a/addon/components/input-validator.js
+++ b/addon/components/input-validator.js
@@ -12,6 +12,7 @@ export default Component.extend({
     classNames: [ 'form-group', 'input-validator' ],
     classNameBindings: ['showError:has-warning', 'label:has-label'],
     labelClass: 'control-label',
+    errorClass: 'invalid-feedback',
     label: false,
     hideErrorText: false,
     hasFocusedOut: false,

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -7,3 +7,12 @@
     display: block;
     margin-top: 0;
 }
+
+.input-validator.is-invalid .custom-select,
+.input-validator.is-invalid .form-control  {
+    border-color: #dc3545;
+}
+
+.input-validator.is-invalid .form-check-label {
+    color: #dc3545;
+}

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -1,6 +1,9 @@
-.input-validator .input-validation-error {
+.input-validator .input-validator-error {
+    min-height: 1.4rem;
+    padding-top: 0.2rem;
+}
+
+.input-validator .input-validator-error .invalid-feedback {
     display: block;
-    min-height: 1.2rem;
-    line-height: 1.2rem;
-    font-size: .75rem;
+    margin-top: 0;
 }

--- a/addon/templates/components/input-validator.hbs
+++ b/addon/templates/components/input-validator.hbs
@@ -1,14 +1,13 @@
 {{#if label}}
-    <h5><label for="{{inputId}}" class="{{labelClass}} input-validator-label">{{fieldLabel}}</label></h5>
+    <label for={{inputId}} class="{{labelClass}} input-validator-label">{{fieldLabel}}</label>
 {{/if}}
-
 {{yield}}
 {{#unless hideErrorText}}
-    <span class="input-validation-error">
+    <div class="input-validator-error">
         {{#if showError}}
-            <span class="text-danger {{errorClass}}">
-                {{or msg error}}
-            </span>
+            <div class={{errorClass}}>
+                {{if msg msg error}}
+            </div>
         {{/if}}
-    </span>
+    </div>
 {{/unless}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gavant-ember-validations",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,14 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+
+    actions: {
+        submitForm() {
+            window.alert('submitted succesfully!');
+        },
+
+        submit(validator) {
+            return validator.submit();
+        }
+    }
+});

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,6 +9,7 @@
 
     {{content-for "head"}}
 
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -4,6 +4,7 @@ import { validatePresence } from 'ember-changeset-validations/validators';
 
 const validations = {
     name: [validatePresence({presence: true, ignoreBlank: true})],
+    radio: [validatePresence({presence: true})]
 };
 
 export default Route.extend(ChangesetRoute, {
@@ -11,7 +12,8 @@ export default Route.extend(ChangesetRoute, {
 
     model() {
         return {
-            name: null
+            name: null,
+            radio: null
         };
     }
 });

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,0 +1,17 @@
+import Route from '@ember/routing/route';
+import ChangesetRoute from 'gavant-ember-validations/mixins/changeset-route';
+import { validatePresence } from 'ember-changeset-validations/validators';
+
+const validations = {
+    name: [validatePresence({presence: true, ignoreBlank: true})],
+};
+
+export default Route.extend(ChangesetRoute, {
+    validations,
+
+    model() {
+        return {
+            name: null
+        };
+    }
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -4,6 +4,16 @@
         {{#input-validator target="name" fieldLabel="Name" label=true}}
             {{input value=changeset.name class="form-control"}}
         {{/input-validator}}
+        {{#input-validator target="radio"}}
+            <div class="form-check">
+                <input type="radio" class="form-check-input" id="radio1" value="1" onclick={{action (mut changeset.radio) "1"}}>
+                <label class="form-check-label" for="radio1">Option 1</label>
+            </div>
+            <div class="form-check">
+                <input type="radio" class="form-check-input" id="radio2" value="1" onclick={{action (mut changeset.radio) "2"}}>
+                <label class="form-check-label" for="radio2">Option 2</label>
+            </div>
+        {{/input-validator}}
         <button class="btn btn-primary" type="submit" {{action "submit" validator}}>Submit</button>
     {{/form-validator}}
 </div>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,10 @@
-<h2 id="title">Welcome to Ember</h2>
-
+<div class="p-3">
+    <h2 id="title">Welcome to Ember</h2>
+    {{#form-validator changeset=changeset submit=(action "submitForm") as |changeset validator|}}
+        {{#input-validator target="name" fieldLabel="Name" label=true}}
+            {{input value=changeset.name class="form-control"}}
+        {{/input-validator}}
+        <button class="btn btn-primary" type="submit" {{action "submit" validator}}>Submit</button>
+    {{/form-validator}}
+</div>
 {{outlet}}

--- a/tests/integration/components/form-validator/child-test.js
+++ b/tests/integration/components/form-validator/child-test.js
@@ -9,14 +9,18 @@ module('Integration | Component | form-validator/child', function(hooks) {
   test('it renders', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
-
-    await render(hbs`{{form-validator/child}}`);
+    this.set('parent', {
+        registerChild: function() {},
+        deregisterChild: function() {}
+    });
+    
+    await render(hbs`{{form-validator/child parent=parent}}`);
 
     assert.equal(this.element.textContent.trim(), '');
 
     // Template block usage:
     await render(hbs`
-      {{#form-validator/child}}
+      {{#form-validator/child parent=parent}}
         template block text
       {{/form-validator/child}}
     `);


### PR DESCRIPTION
The intent of these changes is to better align the `input-validator` component's markup with the current Bootstrap 4 standard form HTML structure and CSS classes:

- remove wrapper `<h5>` from the `<label>` element
- Change from `text-danger` to `invalid-feedback` (and also now can be completely swapped out if needed)
- Switch from `span` to `div` for error message containers

I kept the custom `input-validator-error` container, so that we could still keep the min-height spacing styles (so that the form doesn't "jump" when errors are shown), but removed the extraneous  custom styles, which bootstrap already gives us for the error message (I think those would be better off customized in the application, if needed)

Additionally, I also fixed a failing test, and removed the dependency on ember-truth-helper's `{{or}}` helper (which was actually causing the addon to break in the dummy app, since we dont include the truth-helpers addon as a dep).