### PR TITLE
Modifying GenericChangeset types

### DIFF
--- a/ember-validations/src/components/form-validator/child/index.ts
+++ b/ember-validations/src/components/form-validator/child/index.ts
@@ -2,12 +2,11 @@ import { assert } from '@ember/debug';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import InputValidator from 'components/input-validator';
-
 import { WithBoundArgs } from '@glint/template';
 
 import FormValidator, { ValueForChangeset } from '../';
 import { GenericChangeset } from '../../../utilities/create-changeset';
+import InputValidator from '../../input-validator';
 
 interface FormValidatorChildArgs<C extends GenericChangeset<V>, V = ValueForChangeset<C>> {
     /**

--- a/ember-validations/src/components/form-validator/index.ts
+++ b/ember-validations/src/components/form-validator/index.ts
@@ -4,12 +4,12 @@ import { tracked } from '@glimmer/tracking';
 
 import { BufferedChangeset } from 'ember-changeset/types';
 
-import InputValidator from 'components/input-validator';
 import { all, reject, resolve } from 'rsvp';
 
 import { WithBoundArgs } from '@glint/template';
 
 import { GenericChangeset } from '../../utilities/create-changeset';
+import InputValidator from '../input-validator';
 import FormValidatorChild from './child';
 
 interface FormValidatorArgs<C extends GenericChangeset<V>, V = ValueForChangeset<C>> {

--- a/ember-validations/src/utilities/create-changeset.ts
+++ b/ember-validations/src/utilities/create-changeset.ts
@@ -1,11 +1,21 @@
+import ComputedProperty from '@ember/object/computed';
+
 import Model from '@ember-data/model';
 import { Changeset } from 'ember-changeset';
 import { BufferedChangeset, ValidatorMap } from 'ember-changeset/types';
 
 import { lookupValidator } from 'validated-changeset';
 
-export type GenericChangeset<T> = BufferedChangeset &
-    (T extends Model ? Pick<T, Exclude<keyof T, keyof Model>> : T) & { data: T };
+export type UnwrapComputedProperties<T> = {
+    [Property in keyof T]: T[Property] extends ComputedProperty<infer U, any> ? U : T[Property];
+};
+export type UserModelAttributes<T extends Model> = Pick<T, Exclude<keyof T, keyof Model>>;
+
+export type EmberModelAttributes<T extends Model> = Readonly<
+    UnwrapComputedProperties<Pick<T, Exclude<keyof T, keyof UserModelAttributes<T>>>>
+>;
+export type ChangesetAttributes<T> = T extends Model ? UserModelAttributes<T> & EmberModelAttributes<T> : T;
+export type GenericChangeset<T> = BufferedChangeset & ChangesetAttributes<T> & { data: T };
 
 /**
  * Creates a changeset

--- a/test-app/app/controllers/application.ts
+++ b/test-app/app/controllers/application.ts
@@ -20,6 +20,6 @@ export default class ApplicationController extends Controller {
 
     @action
     updateRadio(value) {
-        this.changeset.radio = value;
+        this.model.radio = value;
     }
 }

--- a/test-app/app/models/test.ts
+++ b/test-app/app/models/test.ts
@@ -1,0 +1,13 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Test extends Model {
+    @attr('string') declare name: string;
+    @attr('string') declare description: string;
+}
+
+// DO NOT DELETE: this is how TypeScript knows how to look up your models.
+declare module 'ember-data/types/registries/model' {
+    export default interface ModelRegistry {
+        test: Test;
+    }
+}

--- a/test-app/app/routes/application.ts
+++ b/test-app/app/routes/application.ts
@@ -22,7 +22,6 @@ const Validations = {
 const childValidations = {
     foo: [validatePresence({ presence: true, ignoreBlank: true })]
 };
-
 export default class Application extends Route {
     validations = Validations;
 

--- a/test-app/tests/unit/models/test-test.ts
+++ b/test-app/tests/unit/models/test-test.ts
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
+module('Unit | Model | test', function (hooks) {
+    setupTest(hooks);
+
+    // Replace this with your real tests.
+    test('it exists', function (assert) {
+        const store = this.owner.lookup('service:store');
+        const model = run(() => store.createRecord('test', {}));
+        assert.ok(model);
+    });
+});

--- a/test-app/types/glint.d.ts
+++ b/test-app/types/glint.d.ts
@@ -1,4 +1,3 @@
 import '@glint/environment-ember-loose';
 
 import '@gavant/ember-validations/glint';
-

--- a/test-app/types/glint.d.ts
+++ b/test-app/types/glint.d.ts
@@ -1,1 +1,4 @@
+import '@glint/environment-ember-loose';
+
 import '@gavant/ember-validations/glint';
+


### PR DESCRIPTION
to allow ember model properties like `isNew` but as readonly